### PR TITLE
added missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,4 @@ websockets==10.4
 yarl==1.9.2
 zipp==3.15.0
 tiktoken==0.4.0
+psycopg2==2.9.6


### PR DESCRIPTION
when I did pip install -r requirements.txt
psycopg2 came as missing so I added it to requirements.txt