### PR TITLE
Remove redundant import statement

### DIFF
--- a/superagi/worker.py
+++ b/superagi/worker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from celery import Celery
 
 from superagi.config.config import get_config


### PR DESCRIPTION
The import statement 'from future import absolute_import' has been removed. This import is not required since Python 3 uses absolute imports by default. Therefore, it is redundant and can be safely removed from the codebase.