### PR TITLE
docker-compose fix for podman

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,12 +39,12 @@ services:
       - /app/.next
 
   super__redis:
-    image: "redis:latest"
+    image: "docker.io/library/redis:latest"
     networks:
       - super_network
 
   super__postgres:
-    image: "postgres:latest"
+    image: "docker.io/library/postgres:latest"
     environment:
       - POSTGRES_USER=superagi
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
Use fully qualified image names instead of aliases to support using podman instead of docker.

By default podman does not support aliases for image names and fails to run SuperAGI using this compose file. In file `/etc/containers/registries.conf` from podman we can find this note:
```txt
# NOTE: RISK OF USING UNQUALIFIED IMAGE NAMES
# We recommend always using fully qualified image names including the registry
# server (full dns name), namespace, image name, and tag
# (e.g., registry.redhat.io/ubi8/ubi:latest). Pulling by digest (i.e.,
# quay.io/repository/name@digest) further eliminates the ambiguity of tags.
# When using short names, there is always an inherent risk that the image being
# pulled could be spoofed. For example, a user wants to pull an image named
# `foobar` from a registry and expects it to come from myregistry.com. If
# myregistry.com is not first in the search list, an attacker could place a
# different `foobar` image at a registry earlier in the search list. The user
# would accidentally pull and run the attacker's image and code rather than the
# intended content. We recommend only adding registries which are completely
# trusted (i.e., registries which don't allow unknown or anonymous users to
# create accounts with arbitrary names). This will prevent an image from being
# spoofed, squatted or otherwise made insecure.  If it is necessary to use one
# of these registries, it should be added at the end of the list.
```
