### PR TITLE
docs: update link to google custom search

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -171,7 +171,7 @@ This video demonstrates how SuperCoder can be used to create simple applications
 |Keys|Accessing the keys|
 |--|--|
 |**OpenAI API Key**| Sign up and create an API key at [OpenAI Developer](https://beta.openai.com/signup/)|
-|**Google API key**| Create a project in the [Google Cloud Console](https://console.cloud.google.com/) and enable the API you need (for example: Google Custom Search JSON API). Then, create an API key in the "Credentials" section.|
+|**Google API key**| Create a project in the [Google Cloud Console](https://console.cloud.google.com/) and enable the API you need (for example: [Google Custom Search JSON API](https://developers.google.com/custom-search/v1/introduction)).|
 |**Custom search engine ID**| Visit [Google Programmable Search Engine](https://programmablesearchengine.google.com/about/) to create a custom search engine for your application and obtain the search engine ID.|
 
 4. Ensure that Docker is installed in your system, if not, Install it from [here](https://docs.docker.com/get-docker/). 


### PR DESCRIPTION
### Description

I spent ~20 minutes trying to follow the current instructions in the README - it doesn't seem to be possible to set up an API key for Google Custom Search JSON from the Google Console. This has to be done in a separate place.

### Related Issues

https://github.com/TransformerOptimus/SuperAGI/issues/155

### Solution and Design

Link to the correct URL where an API key can be created:

https://developers.google.com/custom-search/v1/introduction

### Type of change

- [x] Docs update

### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
