### PR TITLE
dropdown not working in safari bug fixed, FIX #530

### DIFF
--- a/gui/pages/_app.css
+++ b/gui/pages/_app.css
@@ -209,7 +209,7 @@ input[type="range"]::-moz-range-track {
 
 .dropdown_container {
     width: 150px;
-    height: fit-content;
+    height: auto;
     background: #2E293F;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
Resolved the dropdown visibility bug in safari by changing minor css globally


<!-- Changelog Section End -->

### Related Issues
Issue #530 

### Solution and Design
Involved a minor css change in the global css file

### Test Plan
Used different browsers

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.
