### PR TITLE
Conditional statement expanded for errored API response (close #560)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv
 workspace/output
 workspace/input
 ../bfg-report*
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ venv
 workspace/output
 workspace/input
 ../bfg-report*
-.vscode/settings.json

--- a/superagi/agent/super_agi.py
+++ b/superagi/agent/super_agi.py
@@ -165,7 +165,7 @@ class SuperAgi:
         total_tokens = current_tokens + TokenCounter.count_message_tokens(response, self.llm.get_model())
         self.update_agent_execution_tokens(current_calls, total_tokens)
 
-        if response['content'] is None:
+        if 'content' not in response or response['content'] is None:
             raise RuntimeError(f"Failed to get response from llm")
         assistant_reply = response['content']
 

--- a/superagi/jobs/agent_executor.py
+++ b/superagi/jobs/agent_executor.py
@@ -203,7 +203,13 @@ class AgentExecutor:
 
         agent_workflow_step = session.query(AgentWorkflowStep).filter(
             AgentWorkflowStep.id == agent_execution.current_step_id).first()
-        response = spawned_agent.execute(agent_workflow_step)
+        
+        try:
+            response = spawned_agent.execute(agent_workflow_step)
+        except RuntimeError as e:
+            # If our execution encounters an error we respond as an error and attempt to retry
+            response = { "result": "ERROR", "message": str(e) }
+
         if "retry" in response and response["retry"]:
             response = spawned_agent.execute(agent_workflow_step)
         agent_execution.current_step_id = agent_workflow_step.next_step_id

--- a/superagi/jobs/agent_executor.py
+++ b/superagi/jobs/agent_executor.py
@@ -207,7 +207,7 @@ class AgentExecutor:
         try:
             response = spawned_agent.execute(agent_workflow_step)
         except RuntimeError as e:
-            # If our execution encounters an error we respond as an error and attempt to retry
+            # If our execution encounters an error we return and attempt to retry
             return
 
         if "retry" in response and response["retry"]:

--- a/superagi/jobs/agent_executor.py
+++ b/superagi/jobs/agent_executor.py
@@ -208,7 +208,7 @@ class AgentExecutor:
             response = spawned_agent.execute(agent_workflow_step)
         except RuntimeError as e:
             # If our execution encounters an error we respond as an error and attempt to retry
-            response = { "result": "ERROR", "message": str(e) }
+            return
 
         if "retry" in response and response["retry"]:
             response = spawned_agent.execute(agent_workflow_step)


### PR DESCRIPTION
Solved endless loop and hanging UI by extending our error catching by expanding conditional check to properties.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

Solved endless loop and hanging UI by extending our error catching.  We were getting an uncaught exception because response['content'} was throwing a KeyError when response does not contain a 'content' property.  

```
Traceback (most recent call last):
superagi-celery-1           |   File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
superagi-celery-1           |     R = retval = fun(*args, **kwargs)
superagi-celery-1           |   File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
superagi-celery-1           |     return self.run(*args, **kwargs)
superagi-celery-1           |   File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 54, in run
superagi-celery-1           |     ret = task.retry(exc=exc, **retry_kwargs)
superagi-celery-1           |   File "/usr/local/lib/python3.9/site-packages/celery/app/task.py", line 717, in retry
superagi-celery-1           |     raise_with_context(exc)
superagi-celery-1           |   File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 34, in run
superagi-celery-1           |     return task._orig_run(*args, **kwargs)
superagi-celery-1           |   File "/app/superagi/worker.py", line 19, in execute_agent
superagi-celery-1           |     AgentExecutor().execute_next_action(agent_execution_id=agent_execution_id)
superagi-celery-1           |   File "/app/superagi/jobs/agent_executor.py", line 206, in execute_next_action
superagi-celery-1           |     response = spawned_agent.execute(agent_workflow_step)
superagi-celery-1           |   File "/app/superagi/agent/super_agi.py", line 168, in execute
superagi-celery-1           |     if response['content'] is None:
superagi-celery-1           | KeyError: 'content'
```

<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

Resolves #560 #272

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

If we capture the case of a missing property AND the response['content'] is None. Execution continues and we hit max retry threshold.  Original user behavior stays intact because we are not changing the error handling mechanism.  Since we are properly catching errors now we let the UI show the user that the maximum number of retries have been attempted.

Small fixes:

Account for the case when we have no content in our response
```
if 'content' not in response or response['content'] is None:
    raise RuntimeError(f"Failed to get response from llm")
```

Surround execution with try catch to follow existing design:
```
try:
    response = spawned_agent.execute(agent_workflow_step)
except RuntimeError as e:    
    # If our execution encounters an error we respond as an error and attempt to retry
     return
```

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

While there is no test class for `super_agi.py` you can see the manual testing below.
https://www.loom.com/share/028e80623061493a8c167f1aa0df5edb?sid=29e496ec-62ba-4bed-b809-25cf29cd88de

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.
