### PR TITLE
Minor Change in response for Agent Scheduling Endpoint

### DIFF
--- a/superagi/controllers/agent.py
+++ b/superagi/controllers/agent.py
@@ -364,6 +364,8 @@ def get_schedule_data(agent_id: int, Authorize: AuthJWT = Depends(check_auth)):
 
     response_data = {
         "current_datetime": current_datetime,
+        "start_date": agent.start_time.astimezone(tzone).strftime("%d %b %Y"),
+        "start_time": agent.start_time.astimezone(tzone).strftime("%I:%M %p"),
         "recurrence_interval": agent.recurrence_interval if agent.recurrence_interval else None,
         "expiry_date": agent.expiry_date.astimezone(tzone).strftime("%d/%m/%Y") if agent.expiry_date else None,
         "expiry_runs": agent.expiry_runs if agent.expiry_runs != -1 else None

--- a/tests/unit_tests/controllers/test_agent.py
+++ b/tests/unit_tests/controllers/test_agent.py
@@ -33,14 +33,13 @@ def mock_agent_config():
 
 @pytest.fixture
 def mock_schedule_get():
-    # Use predefined start_time
     return AgentSchedule(
         id=1, 
         agent_id=1, 
         status="SCHEDULED",
         start_time= datetime(2022, 1, 1, 10, 30),
         recurrence_interval="5 Minutes",
-        expiry_date=datetime(2022, 1, 1, 10, 30) + timedelta(days=10),  # adjusted expiry_date as well here
+        expiry_date=datetime(2022, 1, 1, 10, 30) + timedelta(days=10),
         expiry_runs=5 
     )
 
@@ -113,14 +112,14 @@ def test_get_schedule_data_success(mock_schedule_get, mock_agent_config):
         response = client.get("agents/get/schedule_data/1")
         assert response.status_code == 200
 
-        time_gmt = mock_schedule_get.start_time.astimezone(timezone('GMT')) # convert to GMT
+        time_gmt = mock_schedule_get.start_time.astimezone(timezone('GMT'))
 
         expected_data = {
             "current_datetime": mock.ANY,
-            "start_date": time_gmt.strftime("%d %b %Y"),  # start_date in GMT
-            "start_time": time_gmt.strftime("%I:%M %p"),  # start_time in GMT
+            "start_date": time_gmt.strftime("%d %b %Y"),
+            "start_time": time_gmt.strftime("%I:%M %p"),
             "recurrence_interval": mock_schedule_get.recurrence_interval,
-            "expiry_date": mock_schedule_get.expiry_date.astimezone(timezone('GMT')).strftime("%d/%m/%Y"), # expiry_date also in GMT
+            "expiry_date": mock_schedule_get.expiry_date.astimezone(timezone('GMT')).strftime("%d/%m/%Y"),
             "expiry_runs": mock_schedule_get.expiry_runs,
         }
         assert response.json() == expected_data

--- a/tests/unit_tests/controllers/test_agent.py
+++ b/tests/unit_tests/controllers/test_agent.py
@@ -105,7 +105,7 @@ def test_edit_schedule_not_found(mock_patch_schedule_input):
         assert response.status_code == 404
         assert response.json() == {"detail": "Schedule not found"}
 
-# '''Test for getting agent schedule'''
+'''Test for getting agent schedule'''
 def test_get_schedule_data_success(mock_schedule_get, mock_agent_config):
     with patch('superagi.controllers.agent.db') as mock_db:
         mock_db.session.query.return_value.filter.return_value.first.side_effect = [mock_schedule_get, mock_agent_config]

--- a/tests/unit_tests/controllers/test_agent.py
+++ b/tests/unit_tests/controllers/test_agent.py
@@ -7,7 +7,8 @@ from main import app
 from superagi.models.agent_schedule import AgentSchedule
 from superagi.models.agent_config import AgentConfiguration
 from superagi.models.agent import Agent
-from datetime import datetime
+from datetime import datetime, timedelta
+from pytz import timezone
 
 client = TestClient(app)
 
@@ -29,6 +30,19 @@ def mock_schedule():
 @pytest.fixture
 def mock_agent_config():
     return AgentConfiguration(key="user_timezone", agent_id=1, value='GMT')
+
+@pytest.fixture
+def mock_schedule_get():
+    # Use predefined start_time
+    return AgentSchedule(
+        id=1, 
+        agent_id=1, 
+        status="SCHEDULED",
+        start_time= datetime(2022, 1, 1, 10, 30),
+        recurrence_interval="5 Minutes",
+        expiry_date=datetime(2022, 1, 1, 10, 30) + timedelta(days=10),  # adjusted expiry_date as well here
+        expiry_runs=5 
+    )
 
 '''Test for Stopping Agent Scheduling'''
 def test_stop_schedule_success(mock_schedule):
@@ -92,26 +106,22 @@ def test_edit_schedule_not_found(mock_patch_schedule_input):
         assert response.status_code == 404
         assert response.json() == {"detail": "Schedule not found"}
 
-'''Test for getting agent schedule'''
-def test_get_schedule_data_success(mock_schedule, mock_agent_config):
+# '''Test for getting agent schedule'''
+def test_get_schedule_data_success(mock_schedule_get, mock_agent_config):
     with patch('superagi.controllers.agent.db') as mock_db:
-        # Set up the database query result
-        
-        mock_db.session.query.return_value.filter.return_value.first.side_effect = [mock_schedule, mock_agent_config]
-
-        # Call the endpoint
+        mock_db.session.query.return_value.filter.return_value.first.side_effect = [mock_schedule_get, mock_agent_config]
         response = client.get("agents/get/schedule_data/1")
-
-
-        # Verify the HTTP response
         assert response.status_code == 200
 
-        # Verify the response data is correct
+        time_gmt = mock_schedule_get.start_time.astimezone(timezone('GMT')) # convert to GMT
+
         expected_data = {
             "current_datetime": mock.ANY,
-            "recurrence_interval": mock_schedule.recurrence_interval,
-            "expiry_date": mock_schedule.expiry_date,
-            "expiry_runs": mock_schedule.expiry_runs,
+            "start_date": time_gmt.strftime("%d %b %Y"),  # start_date in GMT
+            "start_time": time_gmt.strftime("%I:%M %p"),  # start_time in GMT
+            "recurrence_interval": mock_schedule_get.recurrence_interval,
+            "expiry_date": mock_schedule_get.expiry_date.astimezone(timezone('GMT')).strftime("%d/%m/%Y"), # expiry_date also in GMT
+            "expiry_runs": mock_schedule_get.expiry_runs,
         }
         assert response.json() == expected_data
 
@@ -127,7 +137,6 @@ def test_get_schedule_data_not_found():
         # Verify the HTTP response
         assert response.status_code == 404
         assert response.json() == {"detail": "Agent Schedule not found"}
-
 
 
 @pytest.fixture


### PR DESCRIPTION
Minor Change in response for Agent Scheduling Endpoint

### Description
start_time and start_date was needed to be sent to frontend. So, I have added it to the /agents/get/schedule_data endpoint. 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.
