### PR TITLE
feat: added ability to send replies and threads through twitter toolkit

### DIFF
--- a/superagi/tools/twitter/send_tweets.py
+++ b/superagi/tools/twitter/send_tweets.py
@@ -6,13 +6,15 @@ from superagi.helper.twitter_helper import TwitterHelper
 from superagi.helper.twitter_tokens import TwitterTokens
 from superagi.tools.base_tool import BaseTool
 
+import json 
 
 class SendTweetsInput(BaseModel):
     tweet_text: str = Field(...,
                             description="Tweet text to be posted from twitter handle, if no value is given keep the default value as 'None'")
     is_media: bool = Field(..., description="'True' if there is any media to be posted with Tweet else 'False'.")
     media_files: list = Field(..., description="Name of the media files to be uploaded.")
-
+    is_reply: bool = Field(..., description="'True' if you want to reply to any tweet else 'False'.")
+    in_reply_to_tweet_id: str = Field(..., description="Tweet ID of the tweet to which you want to reply to, if no value is given keep the default value as 'None'")
 
 class SendTweetsTool(BaseTool):
     name: str = "Send Tweets Tool"
@@ -21,7 +23,7 @@ class SendTweetsTool(BaseTool):
     agent_id: int = None
     agent_execution_id: int = None
 
-    def _execute(self, is_media: bool, tweet_text: str = 'None', media_files: list = []):
+    def _execute(self, is_media: bool, is_reply: bool, tweet_text: str = None, media_files: list = [], in_reply_to_tweet_id: str = None):
         toolkit_id = self.toolkit_config.toolkit_id
         session = self.toolkit_config.session
         creds = TwitterTokens(session).get_twitter_creds(toolkit_id)
@@ -32,8 +34,11 @@ class SendTweetsTool(BaseTool):
             params["media"] = {"media_ids": media_ids}
         if tweet_text is not None:
             params["text"] = tweet_text
+        if is_reply and in_reply_to_tweet_id is not None:
+            params["reply"] = {"in_reply_to_tweet_id": in_reply_to_tweet_id}
         tweet_response = TwitterHelper().send_tweets(params, creds)
         if tweet_response.status_code == 201:
-            return "Tweet posted successfully!!"
+            resp = tweet_response.json()
+            return "Tweet posted successfully!! Returned Tweet ID: {}".format(resp["data"]["id"])
         else:
-            return "Error posting tweet. (Status code: {})".format(tweet_response.status_code)
+            return "Error posting tweet. (Status code: {}, Original Params: {})".format(tweet_response.status_code, params)

--- a/tests/unit_tests/tools/twitter/test_send_tweets.py
+++ b/tests/unit_tests/tools/twitter/test_send_tweets.py
@@ -11,6 +11,8 @@ class TestSendTweetsInput(unittest.TestCase):
         self.assertEqual(data.tweet_text, 'Hello world')
         self.assertEqual(data.is_media, True)
         self.assertEqual(data.media_files, ['image1.png', 'image2.png'])
+        self.assertEqual(data.is_reply, False)
+        self.assertEqual(data.reply_to_tweet_id, None)
 
 
 class TestSendTweetsTool(unittest.TestCase):


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
This extends the Twitter Toolkit to allow for the creation of threads and general replies on Twitter.

<!-- Changelog Section End -->

### Related Issues
None

### Solution and Design
Added params "is_reply" and "in_reply_to_tweet_id" for send_tweet execute.

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.
