### PR TITLE
Fixed S3 Bucket file size when adding s3 only file

### DIFF
--- a/superagi/helper/resource_helper.py
+++ b/superagi/helper/resource_helper.py
@@ -41,13 +41,16 @@ class ResourceHelper:
             final_path = ResourceHelper.get_agent_write_resource_path(file_name, agent, agent_execution)
         else:
             final_path = ResourceHelper.get_resource_path(file_name)
-        file_size = os.path.getsize(final_path)
 
         file_path = ResourceHelper.get_agent_write_resource_path(file_name, agent, agent_execution)
 
         logger.info("make_written_file_resource:", final_path)
         if StorageType.get_storage_type(get_config("STORAGE_TYPE", StorageType.FILE.value)) == StorageType.S3:
             file_path = "resources" + file_path
+            file_size = S3Helper().get_file_size(file_path=file_path)
+        else:
+            file_size = os.path.getsize(final_path)
+
         existing_resource = session.query(Resource).filter_by(
             name=file_name,
             path=file_path,

--- a/superagi/helper/s3_helper.py
+++ b/superagi/helper/s3_helper.py
@@ -55,6 +55,27 @@ class S3Helper:
     def check_file_exists_in_s3(self, file_path):
         response = self.s3.list_objects_v2(Bucket=get_config("BUCKET_NAME"), Prefix="resources" + file_path)
         return 'Contents' in response
+    
+    def get_file_size(self, file_path):
+        """
+        Get the file size of a specific file in S3.
+
+        Args:
+            file_path (str): The path to the file.
+
+        Raises:
+            HTTPException: If the AWS credentials are not found.
+
+        Returns:
+            int: The size of the file in bytes.
+        """
+        try:
+            file_info = self.s3.head_object(Bucket=self.bucket_name, Key=file_path)
+            file_size = file_info['ContentLength']
+            logger.info("File size retrieved from S3 successfully!")
+            return file_size
+        except:
+            raise HTTPException(status_code=500, detail="AWS credentials not found. Check your configuration.")
 
     def read_from_s3(self, file_path):
         file_path = "resources" + file_path


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

When adding a resource link to the DB that only exists in s3 it throws and error when using the os module to get filesize of the file since it doesn't exist

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->


<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

Added condition to get filesize from s3 instead of the os helper function.
Added a function in the s3 helper function class to get the filesize of a file in a bucket.

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [ x ] My pull request is atomic and focuses on a single change.
- [ x ] I have read the contributing guide and my code conforms to the guidelines.
- [ x ] I have documented my changes clearly and comprehensively.
- [ x ] I have added the required tests.
