### PR TITLE
docker compose up --build : python3.9 conflict with python3.10 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim-bullseye AS compile-image
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y wget libpq-dev gcc g++ python3-dev && \
+    apt-get install --no-install-recommends -y wget libpq-dev gcc g++ && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

This a very small change just removing python3-dev from the docker file.
This caused on conflict error with python:3.10-slim-bullseye when I attempted to run: docker compose up --build.

The base image python:3.10-slim-bullseye already contains the necessary Python development tools, making the explicit installation of python3-dev redundant and error-prone.

<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

I found this issue whilst running "docker compose up --build" not "docker-compose up --build" so it may be related to the issues seen in issue #507

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.
