### PR TITLE
Openai error handling for ratelimit, timeout and try again errors(fix #1255)

### DIFF
--- a/superagi/llms/openai.py
+++ b/superagi/llms/openai.py
@@ -11,6 +11,10 @@ MAX_RETRY_ATTEMPTS = 5
 MIN_WAIT = 30 # Seconds
 MAX_WAIT = 120 # Seconds  
 
+def custom_retry_error_callback(retry_state):
+    logger.info("OpenAi Exception:", retry_state.outcome.exception())
+    return {"error": "ERROR_OPENAI", "message": "Open ai exception: "+str(retry_state.outcome.exception())}
+
 
 class OpenAi(BaseLlm):
     def __init__(self, api_key, model="gpt-4", temperature=0.6, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT"), top_p=1,
@@ -64,6 +68,7 @@ class OpenAi(BaseLlm):
         stop=stop_after_attempt(MAX_RETRY_ATTEMPTS), # Maximum number of retry attempts
         wait=wait_random_exponential(min=MIN_WAIT, max=MAX_WAIT),
         before_sleep=lambda retry_state: logger.info(f"{retry_state.outcome.exception()} (attempt {retry_state.attempt_number})"),
+        retry_error_callback=custom_retry_error_callback
     )
     def chat_completion(self, messages, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT")):
         """

--- a/superagi/llms/openai.py
+++ b/superagi/llms/openai.py
@@ -9,7 +9,7 @@ from superagi.llms.base_llm import BaseLlm
 
 MAX_RETRY_ATTEMPTS = 5
 MIN_WAIT = 30 # Seconds
-MAX_WAIT = 120 # Seconds  
+MAX_WAIT = 300 # Seconds
 
 def custom_retry_error_callback(retry_state):
     logger.info("OpenAi Exception:", retry_state.outcome.exception())

--- a/tests/unit_tests/llms/test_open_ai.py
+++ b/tests/unit_tests/llms/test_open_ai.py
@@ -2,7 +2,6 @@ import openai
 import pytest
 from unittest.mock import MagicMock, patch
 
-import tenacity
 from superagi.llms.openai import OpenAi, MAX_RETRY_ATTEMPTS
 
 

--- a/tests/unit_tests/llms/test_open_ai.py
+++ b/tests/unit_tests/llms/test_open_ai.py
@@ -53,10 +53,10 @@ def test_chat_completion_retry_rate_limit_error(mock_openai, mock_wait_random_ex
     mock_wait_random_exponential.return_value = 0.1
 
     # Act
-    with pytest.raises(tenacity.RetryError):
-        result = openai_instance.chat_completion(messages, max_tokens)
+    result = openai_instance.chat_completion(messages, max_tokens)
 
     # Assert
+    assert result == {"error": "ERROR_OPENAI", "message": "Open ai exception: Rate limit exceeded"}
     assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
 
 
@@ -77,10 +77,10 @@ def test_chat_completion_retry_timeout_error(mock_openai, mock_wait_random_expon
     mock_wait_random_exponential.return_value = 0.1
 
     # Act
-    with pytest.raises(tenacity.RetryError):
-        result = openai_instance.chat_completion(messages, max_tokens)
+    result = openai_instance.chat_completion(messages, max_tokens)
 
     # Assert
+    assert result == {"error": "ERROR_OPENAI", "message": "Open ai exception: Timeout occured"}
     assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
 
 
@@ -101,10 +101,10 @@ def test_chat_completion_retry_try_again_error(mock_openai, mock_wait_random_exp
     mock_wait_random_exponential.return_value = 0.1
 
     # Act
-    with pytest.raises(tenacity.RetryError):
-        result = openai_instance.chat_completion(messages, max_tokens)
+    result = openai_instance.chat_completion(messages, max_tokens)
 
     # Assert
+    assert result == {"error": "ERROR_OPENAI", "message": "Open ai exception: Try Again"}
     assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
 
 

--- a/tests/unit_tests/llms/test_open_ai.py
+++ b/tests/unit_tests/llms/test_open_ai.py
@@ -1,6 +1,9 @@
+import openai
 import pytest
 from unittest.mock import MagicMock, patch
-from superagi.llms.openai import OpenAi
+
+import tenacity
+from superagi.llms.openai import OpenAi, MAX_RETRY_ATTEMPTS
 
 
 @patch('superagi.llms.openai.openai')
@@ -31,6 +34,30 @@ def test_chat_completion(mock_openai):
         frequency_penalty=openai_instance.frequency_penalty,
         presence_penalty=openai_instance.presence_penalty
     )
+
+
+@patch('superagi.llms.openai.wait_random_exponential.__call__')
+@patch('superagi.llms.openai.openai')
+def test_chat_completion_retry_rate_limit_error(mock_openai, mock_wait_random_exponential):
+    # Arrange
+    model = 'gpt-4'
+    api_key = 'test_key'
+    openai_instance = OpenAi(api_key, model=model)
+
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    max_tokens = 100
+
+    mock_openai.ChatCompletion.create.side_effect = openai.error.RateLimitError("Rate limit exceeded")
+
+    # Mock sleep time
+    mock_wait_random_exponential.return_value = 0.1
+
+    # Act
+    with pytest.raises(tenacity.RetryError):
+        result = openai_instance.chat_completion(messages, max_tokens)
+
+    # Assert
+    assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
 
 
 def test_verify_access_key():

--- a/tests/unit_tests/llms/test_open_ai.py
+++ b/tests/unit_tests/llms/test_open_ai.py
@@ -60,6 +60,30 @@ def test_chat_completion_retry_rate_limit_error(mock_openai, mock_wait_random_ex
     assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
 
 
+@patch('superagi.llms.openai.wait_random_exponential.__call__')
+@patch('superagi.llms.openai.openai')
+def test_chat_completion_retry_timeout_error(mock_openai, mock_wait_random_exponential):
+    # Arrange
+    model = 'gpt-4'
+    api_key = 'test_key'
+    openai_instance = OpenAi(api_key, model=model)
+
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    max_tokens = 100
+
+    mock_openai.ChatCompletion.create.side_effect = openai.error.Timeout("Timeout occured")
+
+    # Mock sleep time
+    mock_wait_random_exponential.return_value = 0.1
+
+    # Act
+    with pytest.raises(tenacity.RetryError):
+        result = openai_instance.chat_completion(messages, max_tokens)
+
+    # Assert
+    assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
+
+
 def test_verify_access_key():
     model = 'gpt-4'
     api_key = 'test_key'

--- a/tests/unit_tests/llms/test_open_ai.py
+++ b/tests/unit_tests/llms/test_open_ai.py
@@ -84,6 +84,30 @@ def test_chat_completion_retry_timeout_error(mock_openai, mock_wait_random_expon
     assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
 
 
+@patch('superagi.llms.openai.wait_random_exponential.__call__')
+@patch('superagi.llms.openai.openai')
+def test_chat_completion_retry_try_again_error(mock_openai, mock_wait_random_exponential):
+    # Arrange
+    model = 'gpt-4'
+    api_key = 'test_key'
+    openai_instance = OpenAi(api_key, model=model)
+
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    max_tokens = 100
+
+    mock_openai.ChatCompletion.create.side_effect = openai.error.TryAgain("Try Again")
+
+    # Mock sleep time
+    mock_wait_random_exponential.return_value = 0.1
+
+    # Act
+    with pytest.raises(tenacity.RetryError):
+        result = openai_instance.chat_completion(messages, max_tokens)
+
+    # Assert
+    assert mock_openai.ChatCompletion.create.call_count == MAX_RETRY_ATTEMPTS
+
+
 def test_verify_access_key():
     model = 'gpt-4'
     api_key = 'test_key'


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->
With these changes the agent won't stop if a ratelimit error or timeout error or try again error is hit from the openai library, it will try again. 

<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->
#1255 

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->
The agent will attempt to wait 5 times with an exponential backoff strategy and try again, it will wait for a minimum of 30 seconds and max of 300 seconds.
If after 5 attempts the api call still fails it will return the error.

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->
The code is tested by mocking the api calls to openai and having it return the errors mentioned above and checking if the function has called the api specified number of times and it returns the expected error as a dictionary object.
To reduce the time taken to test, the tencity library's wait_random_exponential function is mocked to only use 0.1 seconds

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update


### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.
