### PR TITLE
Supercoder 1389 Issue Resolved

### DIFF
--- a/superagi/tools/searx/searx.py
+++ b/superagi/tools/searx/searx.py
@@ -46,7 +46,16 @@ class SearxSearchTool(BaseTool):
         Returns:
             Snippets from the Searx search.
         """
-        snippets = search_results(query)
+        try:
+            snippets = search_results(query)
+        except HTTPError as http_err:
+            if http_err.response.status_code == 429:
+                return "Error: Searx returned 429 status code. Too many requests. Please try again later."
+            else:
+                return f"HTTP error occurred: {http_err}"
+        except Exception as err:
+            return f"An error occurred: {err}"
+        
         summary = self.summarise_result(query, snippets)
 
         return summary

--- a/superagi/tools/searx/searx_toolkit.py
+++ b/superagi/tools/searx/searx_toolkit.py
@@ -4,6 +4,31 @@ from typing import List
 from superagi.tools.base_tool import BaseToolkit, BaseTool, ToolConfiguration
 from superagi.tools.searx.searx import SearxSearchTool
 from superagi.types.key_type import ToolConfigKeyType
+import time
+import requests
+
+class SearxSearchTool:
+    def search(self, query):
+        url = "http://your-searx-instance/search"
+        params = {
+            'q': query,
+            'format': 'json'
+        }
+        max_retries = 5
+        backoff_factor = 1
+
+        for attempt in range(max_retries):
+            response = requests.get(url, params=params)
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 429:
+                wait_time = backoff_factor * (2 ** attempt)
+                print(f"Received 429 status code. Retrying in {wait_time} seconds...")
+                time.sleep(wait_time)
+            else:
+                response.raise_for_status()
+
+        raise Exception("Max retries exceeded with 429 status code")
 
 class SearxSearchToolkit(BaseToolkit, ABC):
     name: str = "Searx Toolkit"


### PR DESCRIPTION
To handle the 429 status code error, we need to add a try-except block around the `search_results(query)` call in the `_execute` method of the `SearxSearchTool` class. Specifically, we will catch HTTP errors and handle the 429 status code by either retrying the request after a delay or returning an appropriate error message.
To handle the 429 status code error, we need to implement retry logic with exponential backoff in the `search` method of the `SearxSearchTool` class. This will involve catching the 429 error, waiting for a specified time before retrying the request, and increasing the wait time exponentially with each retry.