### PR TITLE
Fix(Agent): Handle missing tool directory gracefully #957

### DIFF
--- a/superagi/agent/tool_builder.py
+++ b/superagi/agent/tool_builder.py
@@ -65,6 +65,8 @@ class ToolBuilder:
             if os.path.exists(os.path.join(os.getcwd(), tool_path) + '/' + tool.folder_name):
                 tools_dir = tool_path
                 break
+        if not tools_dir:
+            raise ValueError(f"Tool directory not found for tool: {tool.folder_name}")
         parsed_tools_dir = tools_dir.rstrip("/")
         module_name = ".".join(parsed_tools_dir.split("/") + [tool.folder_name, file_name])
 

--- a/superagi/agent/tool_builder.py
+++ b/superagi/agent/tool_builder.py
@@ -59,14 +59,19 @@ class ToolBuilder:
         """
         file_name = self.__validate_filename(filename=tool.file_name)
 
-        tools_dir=""
+        if tool is None:
+            raise ValueError("Tool object is None")
+
+        tools_dir = ""
         tool_paths = ["superagi/tools", "superagi/tools/external_tools", "superagi/tools/marketplace_tools"]
         for tool_path in tool_paths:
             if os.path.exists(os.path.join(os.getcwd(), tool_path) + '/' + tool.folder_name):
                 tools_dir = tool_path
                 break
         if not tools_dir:
-            raise ValueError(f"Tool directory not found for tool: {tool.folder_name}")
+            raise ValueError(
+                f"Tool directory not found for tool: {tool.folder_name}. Searched in: {', '.join(tool_paths)}"
+            )
         parsed_tools_dir = tools_dir.rstrip("/")
         module_name = ".".join(parsed_tools_dir.split("/") + [tool.folder_name, file_name])
 

--- a/tests/unit_tests/agent/test_tool_builder_fix.py
+++ b/tests/unit_tests/agent/test_tool_builder_fix.py
@@ -1,0 +1,38 @@
+
+import unittest
+from unittest.mock import MagicMock, patch
+from superagi.agent.tool_builder import ToolBuilder
+from superagi.models.tool import Tool
+
+class TestToolBuilderFix(unittest.TestCase):
+    def setUp(self):
+        self.session = MagicMock()
+        self.agent_id = 1
+        self.agent_execution_id = 1
+        self.tool_builder = ToolBuilder(self.session, self.agent_id, self.agent_execution_id)
+
+    def test_build_tool_none(self):
+        """Test that ValueError is raised when tool is None"""
+        with self.assertRaises(ValueError) as context:
+            self.tool_builder.build_tool(None)
+        self.assertEqual(str(context.exception), "Tool object is None")
+
+    @patch('os.path.exists')
+    def test_build_tool_directory_not_found(self, mock_exists):
+        """Test that ValueError is raised with detailed message when directory is missing"""
+        # Mock os.path.exists to always return False (directory not found)
+        mock_exists.return_value = False
+        
+        tool = Tool()
+        tool.folder_name = "non_existent_tool"
+        tool.file_name = "tools.py"
+        tool.class_name = "MyTool"
+
+        with self.assertRaises(ValueError) as context:
+            self.tool_builder.build_tool(tool)
+        
+        expected_msg = "Tool directory not found for tool: non_existent_tool. Searched in: superagi/tools, superagi/tools/external_tools, superagi/tools/marketplace_tools"
+        self.assertEqual(str(context.exception), expected_msg)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Problem: 
Imagine a robot (SuperAGI) that was told to fetch a specific tool from a toolbox.

Before: The robot would go to the toolbox, look for the tool, and even if it didn't find it, it would pretend it did. Then, when it tried to use the invisible tool, it would crash instantly with a confusing error message (UnboundLocalError).

The Solution: 

What we did: We added a simple "Safety Check" rule.
Now: The robot looks for the tool. If it doesn't find it, it stops immediately and says, "I cannot find the tool you asked for."
Why it matters?
Stopped the Crash: The program doesn't explode with a weird error anymore.
Clearer Feedback: Instead of a cryptic code error, the user gets a clear message telling them exactly what is wrong (missing file), so they can fix it (by downloading the tool).

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update

### Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have read the contributing guide and my code conforms to the guidelines.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have added the required tests.