### PR TITLE
Add MiniMax as a first-class LLM provider (M3 default)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -89,7 +89,7 @@ A dev-first open source autonomous AI agent framework enabling developers to bui
 - <b>Performance Telemetry</b> - Get insights into your agent’s performance and optimize accordingly.
 - <b>Optimized Token Usage</b> - Control token usage to manage costs effectively.
 - <b>Agent Memory Storage</b> - Enable your agents to learn and adapt by storing their memory.
-- <b>Models</b> - Custom fine tuned models for business specific usecases.
+- <b>Models</b> - Custom fine tuned models for business specific usecases. Supports OpenAI, Google Palm, Replicate, Hugging Face, MiniMax and more.
 - <b>Workflows</b> - Automate tasks with ease using ReAct LLM's predefined steps.
 
 ### 🛠 Toolkits

--- a/gui/pages/Content/Models/ModelForm.js
+++ b/gui/pages/Content/Models/ModelForm.js
@@ -6,7 +6,7 @@ import {BeatLoader, ClipLoader} from "react-spinners";
 import {ToastContainer, toast} from 'react-toastify';
 
 export default function ModelForm({internalId, getModels, sendModelData, env}){
-    const models = env === 'DEV' ? ['OpenAI', 'Replicate', 'Hugging Face', 'Google Palm', 'Local LLM'] : ['OpenAI', 'Replicate', 'Hugging Face', 'Google Palm'];
+    const models = env === 'DEV' ? ['OpenAI', 'Replicate', 'Hugging Face', 'Google Palm', 'MiniMax', 'Local LLM'] : ['OpenAI', 'Replicate', 'Hugging Face', 'Google Palm', 'MiniMax'];
     const [selectedModel, setSelectedModel] = useState('Select a Model');
     const [modelName, setModelName] = useState('');
     const [modelDescription, setModelDescription] = useState('');

--- a/gui/utils/utils.js
+++ b/gui/utils/utils.js
@@ -481,6 +481,7 @@ export const modelIcon = (model) => {
     'Google Palm': '/images/google_palm_logo.svg',
     'Replicate': '/images/replicate_logo.svg',
     'OpenAI': '/images/openai_logo.svg',
+    'MiniMax': '/images/minimax_logo.svg',
   }
 
   return icons[model];
@@ -492,6 +493,7 @@ export const modelGetAuth = (modelProvider) => {
     'Hugging Face': 'https://huggingface.co/settings/tokens',
     'OpenAI': 'https://platform.openai.com/account/api-keys',
     'Google Palm': 'https://developers.generativeai.google/products/palm',
+    'MiniMax': 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
   }
 
   return externalLinks[modelProvider]

--- a/superagi/llms/llm_model_factory.py
+++ b/superagi/llms/llm_model_factory.py
@@ -1,5 +1,6 @@
 from superagi.llms.google_palm import GooglePalm
 from superagi.llms.local_llm import LocalLLM
+from superagi.llms.minimax import MiniMax
 from superagi.llms.openai import OpenAi
 from superagi.llms.replicate import Replicate
 from superagi.llms.hugging_face import HuggingFace
@@ -34,6 +35,9 @@ def get_model(organisation_id, api_key, model="gpt-3.5-turbo", **kwargs):
     elif provider_name == 'Hugging Face':
         print("Provider is Hugging Face")
         return HuggingFace(model=model_instance.model_name, end_point=model_instance.end_point, api_key=api_key, **kwargs)
+    elif provider_name == 'MiniMax':
+        print("Provider is MiniMax")
+        return MiniMax(model=model_instance.model_name, api_key=api_key, **kwargs)
     elif provider_name == 'Local LLM':
         print("Provider is Local LLM")
         return LocalLLM(model=model_instance.model_name, context_length=model_instance.context_length)
@@ -49,6 +53,8 @@ def build_model_with_api_key(provider_name, api_key):
         return GooglePalm(api_key=api_key)
     elif provider_name.lower() == 'hugging face':
         return HuggingFace(api_key=api_key)
+    elif provider_name.lower() == 'minimax':
+        return MiniMax(api_key=api_key)
     elif provider_name.lower() == 'local llm':
         return LocalLLM(api_key=api_key)
     else:

--- a/superagi/llms/minimax.py
+++ b/superagi/llms/minimax.py
@@ -20,12 +20,12 @@ def custom_retry_error_callback(retry_state):
 
 
 class MiniMax(BaseLlm):
-    def __init__(self, api_key, model="MiniMax-M2.5", temperature=0.6, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT"),
+    def __init__(self, api_key, model="MiniMax-M2.7", temperature=0.6, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT"),
                  top_p=1, frequency_penalty=0, presence_penalty=0, number_of_results=1):
         """
         Args:
             api_key (str): The MiniMax API key.
-            model (str): The model name (e.g. MiniMax-M2.5, MiniMax-M2.5-highspeed).
+            model (str): The model name (e.g. MiniMax-M2.7, MiniMax-M2.7-highspeed).
             temperature (float): The temperature. Must be in (0.0, 1.0].
             max_tokens (int): The maximum number of tokens.
             top_p (float): The top p.
@@ -151,7 +151,7 @@ class MiniMax(BaseLlm):
             list: The models.
         """
         try:
-            return ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+            return ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
         except Exception as exception:
             logger.info("MiniMax Exception:", exception)
             return []

--- a/superagi/llms/minimax.py
+++ b/superagi/llms/minimax.py
@@ -20,12 +20,12 @@ def custom_retry_error_callback(retry_state):
 
 
 class MiniMax(BaseLlm):
-    def __init__(self, api_key, model="MiniMax-M2.7", temperature=0.6, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT"),
+    def __init__(self, api_key, model="MiniMax-M3", temperature=0.6, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT"),
                  top_p=1, frequency_penalty=0, presence_penalty=0, number_of_results=1):
         """
         Args:
             api_key (str): The MiniMax API key.
-            model (str): The model name (e.g. MiniMax-M2.7, MiniMax-M2.7-highspeed).
+            model (str): The model name (e.g. MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed).
             temperature (float): The temperature. Must be in (0.0, 1.0].
             max_tokens (int): The maximum number of tokens.
             top_p (float): The top p.
@@ -151,7 +151,7 @@ class MiniMax(BaseLlm):
             list: The models.
         """
         try:
-            return ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+            return ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']
         except Exception as exception:
             logger.info("MiniMax Exception:", exception)
             return []

--- a/superagi/llms/minimax.py
+++ b/superagi/llms/minimax.py
@@ -1,0 +1,157 @@
+import openai
+from openai import APIError, InvalidRequestError
+from openai.error import RateLimitError, AuthenticationError, Timeout, TryAgain
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
+
+from superagi.config.config import get_config
+from superagi.lib.logger import logger
+from superagi.llms.base_llm import BaseLlm
+
+MAX_RETRY_ATTEMPTS = 5
+MIN_WAIT = 30  # Seconds
+MAX_WAIT = 300  # Seconds
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+def custom_retry_error_callback(retry_state):
+    logger.info("MiniMax Exception:", retry_state.outcome.exception())
+    return {"error": "ERROR_MINIMAX", "message": "MiniMax exception: " + str(retry_state.outcome.exception())}
+
+
+class MiniMax(BaseLlm):
+    def __init__(self, api_key, model="MiniMax-M2.5", temperature=0.6, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT"),
+                 top_p=1, frequency_penalty=0, presence_penalty=0, number_of_results=1):
+        """
+        Args:
+            api_key (str): The MiniMax API key.
+            model (str): The model name (e.g. MiniMax-M2.5, MiniMax-M2.5-highspeed).
+            temperature (float): The temperature. Must be in (0.0, 1.0].
+            max_tokens (int): The maximum number of tokens.
+            top_p (float): The top p.
+            frequency_penalty (float): The frequency penalty.
+            presence_penalty (float): The presence penalty.
+            number_of_results (int): The number of results.
+        """
+        self.model = model
+        # MiniMax rejects temperature=0; clamp to a small positive value
+        self.temperature = max(temperature, 0.01) if temperature <= 0 else temperature
+        self.max_tokens = max_tokens
+        self.top_p = top_p
+        self.frequency_penalty = frequency_penalty
+        self.presence_penalty = presence_penalty
+        self.number_of_results = number_of_results
+        self.api_key = api_key
+
+    def get_source(self):
+        return "minimax"
+
+    def get_api_key(self):
+        """
+        Returns:
+            str: The API key.
+        """
+        return self.api_key
+
+    def get_model(self):
+        """
+        Returns:
+            str: The model.
+        """
+        return self.model
+
+    @retry(
+        retry=(
+            retry_if_exception_type(RateLimitError) |
+            retry_if_exception_type(Timeout) |
+            retry_if_exception_type(TryAgain)
+        ),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_random_exponential(min=MIN_WAIT, max=MAX_WAIT),
+        before_sleep=lambda retry_state: logger.info(
+            f"{retry_state.outcome.exception()} (attempt {retry_state.attempt_number})"),
+        retry_error_callback=custom_retry_error_callback
+    )
+    def chat_completion(self, messages, max_tokens=get_config("MAX_MODEL_TOKEN_LIMIT")):
+        """
+        Call the MiniMax chat completion API (OpenAI-compatible).
+
+        Args:
+            messages (list): The messages.
+            max_tokens (int): The maximum number of tokens.
+
+        Returns:
+            dict: The response.
+        """
+        try:
+            # Point to MiniMax's OpenAI-compatible endpoint
+            openai.api_key = self.api_key
+            openai.api_base = MINIMAX_API_BASE
+
+            response = openai.ChatCompletion.create(
+                n=self.number_of_results,
+                model=self.model,
+                messages=messages,
+                temperature=self.temperature,
+                max_tokens=max_tokens,
+                top_p=self.top_p,
+                frequency_penalty=self.frequency_penalty,
+                presence_penalty=self.presence_penalty
+            )
+            content = response.choices[0].message["content"]
+            return {"response": response, "content": content}
+        except RateLimitError as api_error:
+            logger.info("MiniMax RateLimitError:", api_error)
+            raise RateLimitError(str(api_error))
+        except Timeout as timeout_error:
+            logger.info("MiniMax Timeout:", timeout_error)
+            raise Timeout(str(timeout_error))
+        except TryAgain as try_again_error:
+            logger.info("MiniMax TryAgain:", try_again_error)
+            raise TryAgain(str(try_again_error))
+        except AuthenticationError as auth_error:
+            logger.info("MiniMax AuthenticationError:", auth_error)
+            return {"error": "ERROR_AUTHENTICATION",
+                    "message": "Authentication error please check the api keys: " + str(auth_error)}
+        except InvalidRequestError as invalid_request_error:
+            logger.info("MiniMax InvalidRequestError:", invalid_request_error)
+            return {"error": "ERROR_INVALID_REQUEST",
+                    "message": "MiniMax invalid request error: " + str(invalid_request_error)}
+        except Exception as exception:
+            logger.info("MiniMax Exception:", exception)
+            return {"error": "ERROR_MINIMAX", "message": "MiniMax exception: " + str(exception)}
+
+    def verify_access_key(self):
+        """
+        Verify the access key is valid by making a lightweight chat request.
+
+        Returns:
+            bool: True if the access key is valid, False otherwise.
+        """
+        try:
+            openai.api_key = self.api_key
+            openai.api_base = MINIMAX_API_BASE
+            openai.ChatCompletion.create(
+                model=self.model,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+            )
+            return True
+        except AuthenticationError:
+            return False
+        except Exception as exception:
+            logger.info("MiniMax Exception:", exception)
+            return False
+
+    def get_models(self):
+        """
+        Get the available MiniMax models.
+
+        Returns:
+            list: The models.
+        """
+        try:
+            return ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+        except Exception as exception:
+            logger.info("MiniMax Exception:", exception)
+            return []

--- a/superagi/models/models.py
+++ b/superagi/models/models.py
@@ -132,7 +132,7 @@ class Models(DBBaseModel):
             return model  # Return error message if model not found
 
         # Check the 'provider' from ModelsConfig table
-        if not end_point and model["provider"] not in ['OpenAI', 'Google Palm', 'Replicate','Local LLM']:
+        if not end_point and model["provider"] not in ['OpenAI', 'Google Palm', 'Replicate', 'MiniMax', 'Local LLM']:
             return {"error": "End Point is empty or undefined"}
 
         if context_length is None: 

--- a/superagi/models/models_config.py
+++ b/superagi/models/models_config.py
@@ -115,7 +115,7 @@ class ModelsConfig(DBBaseModel):
 
     @classmethod
     def storeMiniMaxModels(cls, session, organisation_id, model_provider_id):
-        default_models = {"MiniMax-M2.5": 204000, "MiniMax-M2.5-highspeed": 204000}
+        default_models = {"MiniMax-M2.7": 204000, "MiniMax-M2.7-highspeed": 204000, "MiniMax-M2.5": 204000, "MiniMax-M2.5-highspeed": 204000}
         installed_models = [model[0] for model in session.query(Models.model_name).filter(Models.org_id == organisation_id).all()]
         for model_name, token_limit in default_models.items():
             if model_name not in installed_models:

--- a/superagi/models/models_config.py
+++ b/superagi/models/models_config.py
@@ -4,6 +4,7 @@ from superagi.models.base_model import DBBaseModel
 from superagi.models.organisation import Organisation
 from superagi.models.project import Project
 from superagi.models.models import Models
+from superagi.llms.minimax import MiniMax
 from superagi.llms.openai import OpenAi
 from superagi.helper.encyption_helper import encrypt_data, decrypt_data
 from fastapi import HTTPException
@@ -85,6 +86,8 @@ class ModelsConfig(DBBaseModel):
             session.flush()
             if model_provider == 'OpenAI':
                 cls.storeGptModels(session, organisation_id, existing_entry.id, model_api_key)
+            elif model_provider == 'MiniMax':
+                cls.storeMiniMaxModels(session, organisation_id, existing_entry.id)
             result = {'message': 'The API key was successfully updated'}
         else:
             new_entry = ModelsConfig(org_id=organisation_id, provider=model_provider,
@@ -94,6 +97,8 @@ class ModelsConfig(DBBaseModel):
             session.flush()
             if model_provider == 'OpenAI':
                 cls.storeGptModels(session, organisation_id, new_entry.id, model_api_key)
+            elif model_provider == 'MiniMax':
+                cls.storeMiniMaxModels(session, organisation_id, new_entry.id)
             result = {'message': 'The API key was successfully stored', 'model_provider_id': new_entry.id}
 
         return result
@@ -107,6 +112,15 @@ class ModelsConfig(DBBaseModel):
             if model not in installed_models and model in default_models:
                 result = Models.store_model_details(session, organisation_id, model, model, '',
                                                  model_provider_id, default_models[model], 'Custom', '', 0)
+
+    @classmethod
+    def storeMiniMaxModels(cls, session, organisation_id, model_provider_id):
+        default_models = {"MiniMax-M2.5": 204000, "MiniMax-M2.5-highspeed": 204000}
+        installed_models = [model[0] for model in session.query(Models.model_name).filter(Models.org_id == organisation_id).all()]
+        for model_name, token_limit in default_models.items():
+            if model_name not in installed_models:
+                Models.store_model_details(session, organisation_id, model_name, model_name, '',
+                                           model_provider_id, token_limit, 'Custom', '', 0)
 
     @classmethod
     def fetch_api_keys(cls, session, organisation_id):

--- a/superagi/models/models_config.py
+++ b/superagi/models/models_config.py
@@ -115,7 +115,7 @@ class ModelsConfig(DBBaseModel):
 
     @classmethod
     def storeMiniMaxModels(cls, session, organisation_id, model_provider_id):
-        default_models = {"MiniMax-M2.7": 204000, "MiniMax-M2.7-highspeed": 204000, "MiniMax-M2.5": 204000, "MiniMax-M2.5-highspeed": 204000}
+        default_models = {"MiniMax-M3": 512000, "MiniMax-M2.7": 204000, "MiniMax-M2.7-highspeed": 204000}
         installed_models = [model[0] for model in session.query(Models.model_name).filter(Models.org_id == organisation_id).all()]
         for model_name, token_limit in default_models.items():
             if model_name not in installed_models:

--- a/superagi/types/model_source_types.py
+++ b/superagi/types/model_source_types.py
@@ -22,7 +22,7 @@ class ModelSourceType(Enum):
         open_ai_models = ['gpt-4', 'gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-32k']
         google_models = ['google-palm-bison-001', 'models/chat-bison-001']
         replicate_models = ['replicate-llama13b-v2-chat']
-        minimax_models = ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+        minimax_models = ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
         if model_name in open_ai_models:
             return ModelSourceType.OpenAI
         if model_name in google_models:

--- a/superagi/types/model_source_types.py
+++ b/superagi/types/model_source_types.py
@@ -22,7 +22,7 @@ class ModelSourceType(Enum):
         open_ai_models = ['gpt-4', 'gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-32k']
         google_models = ['google-palm-bison-001', 'models/chat-bison-001']
         replicate_models = ['replicate-llama13b-v2-chat']
-        minimax_models = ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+        minimax_models = ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']
         if model_name in open_ai_models:
             return ModelSourceType.OpenAI
         if model_name in google_models:

--- a/superagi/types/model_source_types.py
+++ b/superagi/types/model_source_types.py
@@ -6,6 +6,7 @@ class ModelSourceType(Enum):
     OpenAI = 'OpenAi'
     Replicate = 'Replicate'
     HuggingFace = 'Hugging Face'
+    MiniMax = 'MiniMax'
     LocalLLM = 'Local LLM'
 
     @classmethod
@@ -21,12 +22,15 @@ class ModelSourceType(Enum):
         open_ai_models = ['gpt-4', 'gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-32k']
         google_models = ['google-palm-bison-001', 'models/chat-bison-001']
         replicate_models = ['replicate-llama13b-v2-chat']
+        minimax_models = ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
         if model_name in open_ai_models:
             return ModelSourceType.OpenAI
         if model_name in google_models:
             return ModelSourceType.GooglePalm
         if model_name in replicate_models:
             return ModelSourceType.Replicate
+        if model_name in minimax_models:
+            return ModelSourceType.MiniMax
         return ModelSourceType.OpenAI
 
     def __str__(self):

--- a/tests/integration_tests/test_minimax_integration.py
+++ b/tests/integration_tests/test_minimax_integration.py
@@ -19,6 +19,22 @@ class TestMiniMaxIntegration:
     def setup_method(self):
         self.api_key = os.environ["MINIMAX_API_KEY"]
 
+    def test_chat_completion_m27(self):
+        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.7")
+        messages = [{"role": "user", "content": "Say hello in one word."}]
+        result = minimax.chat_completion(messages, max_tokens=50)
+        assert "error" not in result
+        assert "content" in result
+        assert len(result["content"]) > 0
+
+    def test_chat_completion_m27_highspeed(self):
+        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.7-highspeed")
+        messages = [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+        result = minimax.chat_completion(messages, max_tokens=50)
+        assert "error" not in result
+        assert "content" in result
+        assert "4" in result["content"]
+
     def test_chat_completion_m25(self):
         minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.5")
         messages = [{"role": "user", "content": "Say hello in one word."}]
@@ -27,7 +43,7 @@ class TestMiniMaxIntegration:
         assert "content" in result
         assert len(result["content"]) > 0
 
-    def test_chat_completion_highspeed(self):
+    def test_chat_completion_m25_highspeed(self):
         minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.5-highspeed")
         messages = [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
         result = minimax.chat_completion(messages, max_tokens=50)

--- a/tests/integration_tests/test_minimax_integration.py
+++ b/tests/integration_tests/test_minimax_integration.py
@@ -19,6 +19,14 @@ class TestMiniMaxIntegration:
     def setup_method(self):
         self.api_key = os.environ["MINIMAX_API_KEY"]
 
+    def test_chat_completion_m3(self):
+        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M3")
+        messages = [{"role": "user", "content": "Say hello in one word."}]
+        result = minimax.chat_completion(messages, max_tokens=50)
+        assert "error" not in result
+        assert "content" in result
+        assert len(result["content"]) > 0
+
     def test_chat_completion_m27(self):
         minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.7")
         messages = [{"role": "user", "content": "Say hello in one word."}]
@@ -29,22 +37,6 @@ class TestMiniMaxIntegration:
 
     def test_chat_completion_m27_highspeed(self):
         minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.7-highspeed")
-        messages = [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
-        result = minimax.chat_completion(messages, max_tokens=50)
-        assert "error" not in result
-        assert "content" in result
-        assert "4" in result["content"]
-
-    def test_chat_completion_m25(self):
-        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.5")
-        messages = [{"role": "user", "content": "Say hello in one word."}]
-        result = minimax.chat_completion(messages, max_tokens=50)
-        assert "error" not in result
-        assert "content" in result
-        assert len(result["content"]) > 0
-
-    def test_chat_completion_m25_highspeed(self):
-        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.5-highspeed")
         messages = [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
         result = minimax.chat_completion(messages, max_tokens=50)
         assert "error" not in result

--- a/tests/integration_tests/test_minimax_integration.py
+++ b/tests/integration_tests/test_minimax_integration.py
@@ -1,0 +1,44 @@
+"""
+Integration test for MiniMax LLM provider.
+
+This test verifies end-to-end MiniMax chat completion using the real API.
+Requires MINIMAX_API_KEY environment variable to be set.
+Skip with: pytest -m "not integration"
+"""
+import os
+import pytest
+
+from superagi.llms.minimax import MiniMax
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set"
+)
+class TestMiniMaxIntegration:
+    def setup_method(self):
+        self.api_key = os.environ["MINIMAX_API_KEY"]
+
+    def test_chat_completion_m25(self):
+        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.5")
+        messages = [{"role": "user", "content": "Say hello in one word."}]
+        result = minimax.chat_completion(messages, max_tokens=50)
+        assert "error" not in result
+        assert "content" in result
+        assert len(result["content"]) > 0
+
+    def test_chat_completion_highspeed(self):
+        minimax = MiniMax(api_key=self.api_key, model="MiniMax-M2.5-highspeed")
+        messages = [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+        result = minimax.chat_completion(messages, max_tokens=50)
+        assert "error" not in result
+        assert "content" in result
+        assert "4" in result["content"]
+
+    def test_verify_access_key(self):
+        minimax = MiniMax(api_key=self.api_key)
+        assert minimax.verify_access_key() is True
+
+    def test_verify_access_key_invalid(self):
+        minimax = MiniMax(api_key="sk-invalid-key")
+        assert minimax.verify_access_key() is False

--- a/tests/unit_tests/llms/test_minimax.py
+++ b/tests/unit_tests/llms/test_minimax.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from superagi.llms.minimax import MiniMax, MAX_RETRY_ATTEMPTS, MINIMAX_API_BASE
+
+
+def test_get_source():
+    minimax = MiniMax(api_key='test_key')
+    assert minimax.get_source() == "minimax"
+
+
+def test_get_api_key():
+    minimax = MiniMax(api_key='test_key')
+    assert minimax.get_api_key() == 'test_key'
+
+
+def test_get_model_default():
+    minimax = MiniMax(api_key='test_key')
+    assert minimax.get_model() == 'MiniMax-M2.5'
+
+
+def test_get_model_custom():
+    minimax = MiniMax(api_key='test_key', model='MiniMax-M2.5-highspeed')
+    assert minimax.get_model() == 'MiniMax-M2.5-highspeed'
+
+
+def test_get_models():
+    minimax = MiniMax(api_key='test_key')
+    models = minimax.get_models()
+    assert 'MiniMax-M2.5' in models
+    assert 'MiniMax-M2.5-highspeed' in models
+
+
+def test_temperature_clamping():
+    # Temperature=0 should be clamped to 0.01
+    minimax = MiniMax(api_key='test_key', temperature=0)
+    assert minimax.temperature == 0.01
+
+    # Negative temperature should be clamped to 0.01
+    minimax = MiniMax(api_key='test_key', temperature=-0.5)
+    assert minimax.temperature == 0.01
+
+    # Positive temperature should pass through
+    minimax = MiniMax(api_key='test_key', temperature=0.7)
+    assert minimax.temperature == 0.7
+
+
+@patch('superagi.llms.minimax.openai')
+def test_chat_completion(mock_openai):
+    model = 'MiniMax-M2.5'
+    api_key = 'test_key'
+    minimax_instance = MiniMax(api_key, model=model)
+
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    max_tokens = 100
+    mock_chat_response = MagicMock()
+    mock_chat_response.choices[0].message = {"content": "Hello from MiniMax!"}
+    mock_openai.ChatCompletion.create.return_value = mock_chat_response
+
+    result = minimax_instance.chat_completion(messages, max_tokens)
+
+    assert result == {"response": mock_chat_response, "content": "Hello from MiniMax!"}
+    mock_openai.ChatCompletion.create.assert_called_once_with(
+        n=minimax_instance.number_of_results,
+        model=model,
+        messages=messages,
+        temperature=minimax_instance.temperature,
+        max_tokens=max_tokens,
+        top_p=minimax_instance.top_p,
+        frequency_penalty=minimax_instance.frequency_penalty,
+        presence_penalty=minimax_instance.presence_penalty
+    )
+
+
+@patch('superagi.llms.minimax.openai')
+def test_chat_completion_sets_api_base(mock_openai):
+    minimax_instance = MiniMax(api_key='test_key')
+    mock_chat_response = MagicMock()
+    mock_chat_response.choices[0].message = {"content": "test"}
+    mock_openai.ChatCompletion.create.return_value = mock_chat_response
+
+    minimax_instance.chat_completion([{"role": "user", "content": "hi"}], 100)
+
+    # Verify the API base was set to MiniMax endpoint
+    assert mock_openai.api_base == MINIMAX_API_BASE
+    assert mock_openai.api_key == 'test_key'
+
+
+@patch('superagi.llms.minimax.openai')
+def test_chat_completion_authentication_error(mock_openai):
+    import openai
+    minimax_instance = MiniMax(api_key='bad_key')
+    mock_openai.ChatCompletion.create.side_effect = openai.error.AuthenticationError("Invalid API key")
+
+    result = minimax_instance.chat_completion([{"role": "user", "content": "hi"}], 100)
+
+    assert result["error"] == "ERROR_AUTHENTICATION"
+    assert "Authentication error" in result["message"]
+
+
+@patch('superagi.llms.minimax.openai')
+def test_chat_completion_generic_exception(mock_openai):
+    minimax_instance = MiniMax(api_key='test_key')
+    mock_openai.ChatCompletion.create.side_effect = Exception("Something went wrong")
+
+    result = minimax_instance.chat_completion([{"role": "user", "content": "hi"}], 100)
+
+    assert result["error"] == "ERROR_MINIMAX"
+    assert "MiniMax exception" in result["message"]
+
+
+@patch('superagi.llms.minimax.openai')
+def test_verify_access_key_success(mock_openai):
+    minimax = MiniMax(api_key='valid_key')
+    mock_openai.ChatCompletion.create.return_value = MagicMock()
+    result = minimax.verify_access_key()
+    assert result is True
+
+
+@patch('superagi.llms.minimax.openai')
+def test_verify_access_key_failure(mock_openai):
+    import openai
+    minimax = MiniMax(api_key='bad_key')
+    mock_openai.ChatCompletion.create.side_effect = openai.error.AuthenticationError("Invalid key")
+    result = minimax.verify_access_key()
+    assert result is False

--- a/tests/unit_tests/llms/test_minimax.py
+++ b/tests/unit_tests/llms/test_minimax.py
@@ -16,7 +16,7 @@ def test_get_api_key():
 
 def test_get_model_default():
     minimax = MiniMax(api_key='test_key')
-    assert minimax.get_model() == 'MiniMax-M2.7'
+    assert minimax.get_model() == 'MiniMax-M3'
 
 
 def test_get_model_custom():
@@ -27,12 +27,17 @@ def test_get_model_custom():
 def test_get_models():
     minimax = MiniMax(api_key='test_key')
     models = minimax.get_models()
+    assert 'MiniMax-M3' in models
     assert 'MiniMax-M2.7' in models
     assert 'MiniMax-M2.7-highspeed' in models
-    assert 'MiniMax-M2.5' in models
-    assert 'MiniMax-M2.5-highspeed' in models
-    # M2.7 should appear before M2.5
-    assert models.index('MiniMax-M2.7') < models.index('MiniMax-M2.5')
+    # M3 should appear first (as the default)
+    assert models.index('MiniMax-M3') < models.index('MiniMax-M2.7')
+    # Older models should be removed
+    assert 'MiniMax-M2.5' not in models
+    assert 'MiniMax-M2.5-highspeed' not in models
+    assert 'MiniMax-M2.1' not in models
+    assert 'MiniMax-M2' not in models
+    assert 'MiniMax-M1' not in models
 
 
 def test_temperature_clamping():
@@ -51,7 +56,7 @@ def test_temperature_clamping():
 
 @patch('superagi.llms.minimax.openai')
 def test_chat_completion(mock_openai):
-    model = 'MiniMax-M2.5'
+    model = 'MiniMax-M3'
     api_key = 'test_key'
     minimax_instance = MiniMax(api_key, model=model)
 

--- a/tests/unit_tests/llms/test_minimax.py
+++ b/tests/unit_tests/llms/test_minimax.py
@@ -16,19 +16,23 @@ def test_get_api_key():
 
 def test_get_model_default():
     minimax = MiniMax(api_key='test_key')
-    assert minimax.get_model() == 'MiniMax-M2.5'
+    assert minimax.get_model() == 'MiniMax-M2.7'
 
 
 def test_get_model_custom():
-    minimax = MiniMax(api_key='test_key', model='MiniMax-M2.5-highspeed')
-    assert minimax.get_model() == 'MiniMax-M2.5-highspeed'
+    minimax = MiniMax(api_key='test_key', model='MiniMax-M2.7-highspeed')
+    assert minimax.get_model() == 'MiniMax-M2.7-highspeed'
 
 
 def test_get_models():
     minimax = MiniMax(api_key='test_key')
     models = minimax.get_models()
+    assert 'MiniMax-M2.7' in models
+    assert 'MiniMax-M2.7-highspeed' in models
     assert 'MiniMax-M2.5' in models
     assert 'MiniMax-M2.5-highspeed' in models
+    # M2.7 should appear before M2.5
+    assert models.index('MiniMax-M2.7') < models.index('MiniMax-M2.5')
 
 
 def test_temperature_clamping():

--- a/tests/unit_tests/llms/test_model_factory.py
+++ b/tests/unit_tests/llms/test_model_factory.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from superagi.llms.google_palm import GooglePalm
 from superagi.llms.hugging_face import HuggingFace
 from superagi.llms.llm_model_factory import get_model, build_model_with_api_key
+from superagi.llms.minimax import MiniMax
 from superagi.llms.openai import OpenAi
 from superagi.llms.replicate import Replicate
 
@@ -73,6 +74,13 @@ def test_build_model_with_hugging_face(mock_hugging_face, monkeypatch):
     monkeypatch.setattr('superagi.llms.llm_model_factory.HuggingFace', mock_hugging_face)  # Replace 'your_module' with the actual module name
     model = build_model_with_api_key('Hugging Face', 'fake_key')
     mock_hugging_face.assert_called_once_with(api_key='fake_key')
+    assert isinstance(model, Mock)
+
+def test_build_model_with_minimax(monkeypatch):
+    mock_minimax = Mock(spec=MiniMax)
+    monkeypatch.setattr('superagi.llms.llm_model_factory.MiniMax', mock_minimax)
+    model = build_model_with_api_key('MiniMax', 'fake_key')
+    mock_minimax.assert_called_once_with(api_key='fake_key')
     assert isinstance(model, Mock)
 
 def test_build_model_with_unknown_provider(capsys):  # capsys is a built-in pytest fixture for capturing print output


### PR DESCRIPTION
## Summary
Add MiniMax as a sixth LLM provider alongside OpenAI, Google Palm, Replicate, Hugging Face, and Local LLM.

## Changes
- Add `MiniMax` provider class with OpenAI-compatible API integration
- Add MiniMax to the LLM model factory, model source types, and GUI model selection
- **Default model: MiniMax-M3** (latest model, 512K context window, up to 128K output, with image input support)
- Available models: MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed
- Temperature clamping (min 0.01) to comply with MiniMax API constraints
- Unit tests for provider, factory, and model configuration
- Integration tests for real API calls

## Why
MiniMax-M3 is the latest model with a 512K context window, up to 128K output, and image input support. MiniMax-M2.7 and MiniMax-M2.7-highspeed are retained as alternatives. The provider uses MiniMax's OpenAI-compatible endpoint at `https://api.minimax.io/v1`.

## Testing
- Unit tests updated and passing
- Integration tested with real MiniMax API (M3, M2.7, M2.7-highspeed, key verification)